### PR TITLE
Add evaluation logging

### DIFF
--- a/phasic_policy_gradient/envs.py
+++ b/phasic_policy_gradient/envs.py
@@ -2,11 +2,12 @@ import numpy as np
 import gym3
 from procgen import ProcgenGym3Env
 
-def get_procgen_venv(*, env_id, num_envs, rendering=False, **env_kwargs):
+def get_procgen_venv(*, env_id, num_envs, distribution_mode, start_level, num_levels, rendering=False, **env_kwargs):
     if rendering:
         env_kwargs["render_human"] = True
-
-    env = ProcgenGym3Env(num=num_envs, env_name=env_id, **env_kwargs)
+    env = ProcgenGym3Env(num=num_envs, env_name=env_id, \
+        distribution_mode=distribution_mode, start_level=start_level, \
+        num_levels=num_levels, **env_kwargs)
 
     env = gym3.ExtractDictObWrapper(env, "rgb")
 
@@ -14,7 +15,9 @@ def get_procgen_venv(*, env_id, num_envs, rendering=False, **env_kwargs):
         env = gym3.ViewerWrapper(env, info_key="rgb")
     return env
 
-def get_venv(num_envs, env_name, **env_kwargs):
-    venv = get_procgen_venv(num_envs=num_envs, env_id=env_name, **env_kwargs)
+def get_venv(num_envs, env_name, distribution_mode, start_level, num_levels, **env_kwargs):
+    venv = get_procgen_venv(num_envs=num_envs, env_id=env_name, \
+        distribution_mode=distribution_mode, start_level=start_level, \
+        num_levels=num_levels, **env_kwargs)
 
     return venv

--- a/phasic_policy_gradient/log_save_helper.py
+++ b/phasic_policy_gradient/log_save_helper.py
@@ -53,6 +53,7 @@ class LogSaveHelper:
         self.log_callbacks = log_callbacks
         self.log_new_eps = log_new_eps
         self.roller_stats = {}
+        self.eval_roller_stats = {}
 
     def __call__(self):
         self.total_interact_count += self.ic_per_step
@@ -85,6 +86,26 @@ class LogSaveHelper:
                 }
             )
 
+    def gather_eval_roller_stats(self, roller):
+        self.eval_roller_stats = {
+            "EpRewMeanTest": self._nanmean([] if roller is None else roller.recent_eprets),
+            "EpLenMeanTest": self._nanmean([] if roller is None else roller.recent_eplens),
+        }
+        if roller is not None and self.log_new_eps:
+            assert roller.has_non_rolling_eps, "roller needs keep_non_rolling"
+            ret_n, ret_mean, ret_std = self._nanmoments(roller.non_rolling_eprets)
+            _len_n, len_mean, len_std = self._nanmoments(roller.non_rolling_eplens)
+            roller.clear_non_rolling_episode_buf()
+            self.eval_roller_stats.update(
+                {
+                    "NewEpNumTest": ret_n,
+                    "NewEpRewMeanTest": ret_mean,
+                    "NewEpRewStdTest": ret_std,
+                    "NewEpLenMeanTest": len_mean,
+                    "NewEpLenStdTest": len_std,
+                }
+            )
+
     def log(self):
         if self.log_callbacks is not None:
             for callback in self.log_callbacks:
@@ -93,7 +114,8 @@ class LogSaveHelper:
         for k, v in self.roller_stats.items():
             logger.logkv(k, v)
 
-        logger.logkv("Misc/InteractCount", self.total_interact_count)
+        for k, v in self.eval_roller_stats.items():
+            logger.logkv(k, v)
         cur_time = time.time()
         Δtime = cur_time - self.last_time
         Δic = self.total_interact_count - self.last_ic

--- a/phasic_policy_gradient/logger.py
+++ b/phasic_policy_gradient/logger.py
@@ -472,6 +472,7 @@ def configure(
     dir: "(str|None) Local directory to write to" = None,
     format_strs: "(str|None) list of formats" = None,
     comm: "(MPI communicator | None) average numerical stats over comm" = None,
+    suffix: "(str) suffix of the file to write to" = None,
 ):
     if dir is None:
         if os.getenv("OPENAI_LOGDIR"):

--- a/phasic_policy_gradient/ppg.py
+++ b/phasic_policy_gradient/ppg.py
@@ -218,6 +218,7 @@ def learn(
     *,
     model,
     venv,
+    eval_venv,
     ppo_hps,
     aux_lr,
     aux_mbsize,
@@ -245,6 +246,7 @@ def learn(
         # Policy phase
         ppo_state = ppo.learn(
             venv=venv,
+            eval_venv=eval_venv,
             model=model,
             learn_state=ppo_state,
             callbacks=[


### PR DESCRIPTION
This commit adds periodic logging of evaluation scores for the policy being trained.

It also adds `num_levels` and `start_level` to the arguments. 

Based on code from @rraileanu